### PR TITLE
Add a [@to_dyn ...] attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ### Added
 
 - Initial implementation of `ppx_deriving_dyn`
+- Allow overriding the default `Dyn.t` converter for a given type or record
+  field via the `[@to_dyn ...]` attribute
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,3 +61,44 @@ val to_dyn : t Dyn.builder
 - An `'a Dyn.builder` extra argument is expected for each type parameter,
   following the declaration order, e.g. for a `type ('a, 'b) t` it will generate
   `val to_dyn : 'a Dyn.builder -> 'b Dyn.builder -> ('a, 'b) t Dyn.builder` 
+
+## Advanced Usage
+
+### Configuration attributes
+
+`ppx_deriving_dyn` allows you to override the default behaviour using the
+following attributes.
+
+#### `[@to_dyn ...]`
+
+It can be used as `[@to_dyn ...]` or `[@ppx_deriving_dyn.to_dyn ...]` and allows
+you to define how a specific part of a type should be converted to a `Dyn.t`
+value by attaching this attribute to it and passing the function to use in the
+payload.
+
+Here are some examples on how to use it:
+```ocaml
+type t = float [@to_dyn special_float_to_dyn]
+[@@deriving dyn]
+```
+
+```ocaml
+type t = int * string * (bool [@to_dyn fun b -> Dyn.string (string_of_bool b)])
+[@@deriving dyn]
+```
+
+```ocaml
+type t =
+  { a : int
+  ; b : string option
+       [@to_dyn
+         function
+         | Some s -> Dyn.string s
+         | None -> Dyn.string "null"]
+  }
+[@@deriving dyn]
+```
+
+The attribute can be attached to a core type or record field and accepts
+function identifier, partial function applications and anonymous functions as
+payload.

--- a/deriver/attr.ml
+++ b/deriver/attr.ml
@@ -1,0 +1,44 @@
+open Ppxlib
+
+let get_attr ~wrap_err_ext attr ast =
+  match Attribute.get_res attr ast with
+  | Ok opt -> opt
+  | Error (err, _) ->
+    let loc = Location.Error.get_location err in
+    Some (wrap_err_ext ~loc (Location.Error.to_extension err))
+;;
+
+module To_dyn = struct
+  let name = "ppx_deriving_dyn.to_dyn"
+
+  let payload_pattern =
+    let open Ast_pattern in
+    let ident_expr = as__ (pexp_ident drop) in
+    let apply_expr = as__ (pexp_apply drop drop) in
+    let fun_expr = as__ (pexp_fun drop drop drop drop) in
+    let function_expr = as__ (pexp_function drop) in
+    single_expr_payload (ident_expr ||| apply_expr ||| fun_expr ||| function_expr)
+  ;;
+
+  let get_attr attr ast =
+    get_attr ~wrap_err_ext:Ast_builder.Default.pexp_extension attr ast
+  ;;
+
+  let core_type_attr =
+    Attribute.declare name Attribute.Context.core_type payload_pattern (fun expr -> expr)
+  ;;
+
+  let from_core_type core_type = get_attr core_type_attr core_type
+
+  let label_decl_attr =
+    Attribute.declare
+      name
+      Attribute.Context.label_declaration
+      payload_pattern
+      (fun expr -> expr)
+  ;;
+
+  let from_label_declaration label_declaration =
+    get_attr label_decl_attr label_declaration
+  ;;
+end

--- a/deriver/attr.mli
+++ b/deriver/attr.mli
@@ -1,0 +1,14 @@
+open Ppxlib
+
+module To_dyn : sig
+  (** Attribute to overwrite the default [to_dyn] converter derived for a given
+      type.
+      The converter to use instead is embedded in the payload as a function,
+      potentially anonymous. *)
+
+  (** Return the user provided converter for the given type, if any. *)
+  val from_core_type : core_type -> expression option
+
+  (** Return the user provided converter for the given record label, if any. *)
+  val from_label_declaration : label_declaration -> expression option
+end

--- a/deriver/error.ml
+++ b/deriver/error.ml
@@ -1,0 +1,24 @@
+open Ppxlib
+
+let error_extensionf ~loc fmt =
+  Location.error_extensionf ~loc ("ppx_deriving_dyn: " ^^ fmt)
+;;
+
+let unsupported_mutually_rec_type_decl ~loc =
+  error_extensionf ~loc "Mutually recursive type declarations are not supported."
+;;
+
+let unsupported_type_param ~loc = error_extensionf ~loc "unsupported type parameter"
+let unsupported_longident ~loc = error_extensionf ~loc "unsupported longident"
+let unsupported_type ~loc = error_extensionf ~loc "cannot derive to_dyn for this type"
+let unsupported_gadt ~loc = error_extensionf ~loc "cannot derive to_dyn for GADTs"
+
+let unsupported_rinherit ~loc =
+  error_extensionf ~loc "cannot derive to_dyn for inherited polymorphic variant types."
+;;
+
+let unsupported_conjunctive_tag_arg ~loc =
+  error_extensionf
+    ~loc
+    "cannot derive to_dyn for polymorphic variant tag with conjunctive type argument."
+;;

--- a/deriver/error.mli
+++ b/deriver/error.mli
@@ -1,0 +1,9 @@
+open Ppxlib
+
+val unsupported_mutually_rec_type_decl : loc:Location.t -> extension
+val unsupported_type_param : loc:Location.t -> extension
+val unsupported_longident : loc:Location.t -> extension
+val unsupported_type : loc:Location.t -> extension
+val unsupported_gadt : loc:Location.t -> extension
+val unsupported_rinherit : loc:Location.t -> extension
+val unsupported_conjunctive_tag_arg : loc:Location.t -> extension

--- a/test/deriver/dune
+++ b/test/deriver/dune
@@ -42,4 +42,4 @@
  (name test_to_dyn)
  (libraries dyn)
  (preprocess
-  (pps ppx_deriving_dyn)))
+  (pps ppx_deriving_dyn -check)))

--- a/test/deriver/test_to_dyn.ml
+++ b/test/deriver/test_to_dyn.ml
@@ -53,3 +53,28 @@ module Base_types = struct
   type t12 = int * string [@@deriving dyn]
   type t13 = int * string * bool [@@deriving dyn]
 end
+
+module To_dyn_attr = struct
+  type t = (int[@ppx_deriving_dyn.to_dyn Dyn.opaque]) [@@deriving dyn]
+
+  type t1 = int * ((int * string)[@to_dyn fun (_, s) -> Dyn.string s]) * bool
+  [@@deriving dyn]
+
+  type t2 =
+    { a : int
+    ; b : string option
+         [@to_dyn
+           function
+           | Some s -> Dyn.string s
+           | None -> Dyn.string "null"]
+    }
+  [@@deriving dyn]
+
+  type t3 =
+    | A
+    | B of
+        { a : int
+        ; b : bool [@to_dyn fun x -> Dyn.string (string_of_bool x)]
+        }
+  [@@deriving dyn] [@@ocaml.warning "-37"]
+end


### PR DESCRIPTION
This allows the user to simply pass a Dyn.builder of their choice.

This should simplify some parts of the dune codebase where we use a slightly modified `to_dyn` function that can easily be derived using this attibute.

I first started by naming some types or shadowing default dyn builders but an attribute is definitely a much cleaner and more robust way to override the default behaviour.