### PR TITLE
Use Dyn.result for result types

### DIFF
--- a/deriver/ppx_deriving_dyn.ml
+++ b/deriver/ppx_deriving_dyn.ml
@@ -19,6 +19,7 @@ module Impl = struct
     | Lident ("bool" as s)
     | Lident ("list" as s)
     | Lident ("array" as s)
+    | Lident ("result" as s)
     | Lident ("option" as s) ->
       Ast_builder.Default.pexp_ident ~loc { txt = Ldot (Lident "Dyn", s); loc }
     | Lident s -> Ast_builder.Default.evar ~loc (to_dyn_name s)

--- a/test/deriver/test_to_dyn.expected.ml
+++ b/test/deriver/test_to_dyn.expected.ml
@@ -147,6 +147,12 @@ module Base_types =
     type 'a t11 = 'a option[@@deriving dyn]
     include struct let t11_to_dyn a_to_dyn t11 = Dyn.option a_to_dyn t11 end
     [@@ocaml.doc "@inline"][@@merlin.hide ]
+    type ('a, 'b) t12 = ('a, 'b) result[@@deriving dyn]
+    include
+      struct
+        let t12_to_dyn a_to_dyn b_to_dyn t12 =
+          Dyn.result a_to_dyn b_to_dyn t12
+      end[@@ocaml.doc "@inline"][@@merlin.hide ]
   end
 module To_dyn_attr =
   struct

--- a/test/deriver/test_to_dyn.ml
+++ b/test/deriver/test_to_dyn.ml
@@ -73,6 +73,7 @@ module Base_types = struct
   type 'a t9 = 'a list [@@deriving dyn]
   type 'a t10 = 'a array [@@deriving dyn]
   type 'a t11 = 'a option [@@deriving dyn]
+  type ('a, 'b) t12 = ('a, 'b) result [@@deriving dyn]
 end
 
 module To_dyn_attr = struct


### PR DESCRIPTION
This depends on dune.3.13+ which hasn't been released so I'm marking it as draft until then.