### PR TITLE
Support recursive and mutually recursive types

### DIFF
--- a/deriver/error.ml
+++ b/deriver/error.ml
@@ -4,10 +4,6 @@ let error_extensionf ~loc fmt =
   Location.error_extensionf ~loc ("ppx_deriving_dyn: " ^^ fmt)
 ;;
 
-let unsupported_mutually_rec_type_decl ~loc =
-  error_extensionf ~loc "Mutually recursive type declarations are not supported."
-;;
-
 let unsupported_type_param ~loc = error_extensionf ~loc "unsupported type parameter"
 let unsupported_longident ~loc = error_extensionf ~loc "unsupported longident"
 let unsupported_type ~loc = error_extensionf ~loc "cannot derive to_dyn for this type"

--- a/deriver/error.mli
+++ b/deriver/error.mli
@@ -1,6 +1,5 @@
 open Ppxlib
 
-val unsupported_mutually_rec_type_decl : loc:Location.t -> extension
 val unsupported_type_param : loc:Location.t -> extension
 val unsupported_longident : loc:Location.t -> extension
 val unsupported_type : loc:Location.t -> extension

--- a/deriver/ppx_deriving_dyn.ml
+++ b/deriver/ppx_deriving_dyn.ml
@@ -327,11 +327,9 @@ module Impl = struct
 
   let generate ~ctxt (rec_flag, type_declarations) =
     let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+    let rec_flag = really_recursive rec_flag type_declarations in
     match type_declarations with
     | [] -> assert false
-    | [ type_declaration ] ->
-      let value_binding = value_binding ~loc type_declaration in
-      [ Ast_builder.Default.pstr_value ~loc Nonrecursive [ value_binding ] ]
     | type_decls ->
       let value_bindings = List.map (value_binding ~loc) type_decls in
       [ Ast_builder.Default.pstr_value ~loc rec_flag value_bindings ]

--- a/test/deriver/test_to_dyn.expected.ml
+++ b/test/deriver/test_to_dyn.expected.ml
@@ -66,6 +66,17 @@ include
        | `C (x0, x1) -> Dyn.variant "C" [Dyn.int x0; Dyn.string x1])
         polymorphic_variant
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type recursive =
+  | Leaf 
+  | Node of recursive * recursive [@@deriving dyn][@@ocaml.warning "-37"]
+include
+  struct
+    let rec recursive_to_dyn =
+      function
+      | Leaf -> Dyn.variant "Leaf" []
+      | Node (x0, x1) ->
+          Dyn.variant "Node" [recursive_to_dyn x0; recursive_to_dyn x1]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 type mrec_1 =
   | A of int 
   | B of mrec_2 

--- a/test/deriver/test_to_dyn.expected.ml
+++ b/test/deriver/test_to_dyn.expected.ml
@@ -66,6 +66,36 @@ include
        | `C (x0, x1) -> Dyn.variant "C" [Dyn.int x0; Dyn.string x1])
         polymorphic_variant
   end[@@ocaml.doc "@inline"][@@merlin.hide ]
+type mrec_1 =
+  | A of int 
+  | B of mrec_2 
+  | C of mrec_3 [@@ocaml.warning "-37"]
+and mrec_2 =
+  | D of mrec_1 
+  | E of string 
+  | F of mrec_3 [@@ocaml.warning "-37"]
+and mrec_3 =
+  | G of mrec_1 
+  | H of mrec_2 
+  | I of bool [@@deriving dyn][@@ocaml.warning "-37"]
+include
+  struct
+    let rec mrec_1_to_dyn =
+      function
+      | A a -> Dyn.variant "A" [Dyn.int a]
+      | B b -> Dyn.variant "B" [mrec_2_to_dyn b]
+      | C c -> Dyn.variant "C" [mrec_3_to_dyn c]
+    and mrec_2_to_dyn =
+      function
+      | D d -> Dyn.variant "D" [mrec_1_to_dyn d]
+      | E e -> Dyn.variant "E" [Dyn.string e]
+      | F f -> Dyn.variant "F" [mrec_3_to_dyn f]
+    and mrec_3_to_dyn =
+      function
+      | G g -> Dyn.variant "G" [mrec_1_to_dyn g]
+      | H h -> Dyn.variant "H" [mrec_2_to_dyn h]
+      | I i -> Dyn.variant "I" [Dyn.bool i]
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 module Base_types =
   struct
     type t = int[@@deriving dyn]

--- a/test/deriver/test_to_dyn.expected.mli
+++ b/test/deriver/test_to_dyn.expected.mli
@@ -21,6 +21,15 @@ type long_tuple
 val long_tuple_to_dyn : long_tuple Dyn.builder
 type polymorphic_variant
 val polymorphic_variant_to_dyn : polymorphic_variant Dyn.builder
+type mrec_1
+and mrec_2
+and mrec_3[@@deriving dyn]
+include
+  sig
+    val mrec_1_to_dyn : mrec_1 Dyn.builder
+    val mrec_2_to_dyn : mrec_2 Dyn.builder
+    val mrec_3_to_dyn : mrec_3 Dyn.builder
+  end[@@ocaml.doc "@inline"][@@merlin.hide ]
 module Base_types :
 sig
   type t[@@deriving dyn]

--- a/test/deriver/test_to_dyn.ml
+++ b/test/deriver/test_to_dyn.ml
@@ -37,6 +37,24 @@ type polymorphic_variant =
   ]
 [@@deriving dyn]
 
+type mrec_1 =
+  | A of int
+  | B of mrec_2
+  | C of mrec_3
+[@@ocaml.warning "-37"]
+
+and mrec_2 =
+  | D of mrec_1
+  | E of string
+  | F of mrec_3
+[@@ocaml.warning "-37"]
+
+and mrec_3 =
+  | G of mrec_1
+  | H of mrec_2
+  | I of bool
+[@@deriving dyn] [@@ocaml.warning "-37"]
+
 module Base_types = struct
   type t = int [@@deriving dyn]
   type t1 = unit [@@deriving dyn]

--- a/test/deriver/test_to_dyn.ml
+++ b/test/deriver/test_to_dyn.ml
@@ -37,6 +37,11 @@ type polymorphic_variant =
   ]
 [@@deriving dyn]
 
+type recursive =
+  | Leaf
+  | Node of recursive * recursive
+[@@deriving dyn] [@@ocaml.warning "-37"]
+
 type mrec_1 =
   | A of int
   | B of mrec_2

--- a/test/deriver/test_to_dyn.mli
+++ b/test/deriver/test_to_dyn.mli
@@ -23,6 +23,10 @@ type polymorphic_variant
 
 val polymorphic_variant_to_dyn : polymorphic_variant Dyn.builder
 
+type mrec_1
+and mrec_2
+and mrec_3 [@@deriving dyn]
+
 module Base_types : sig
   type t [@@deriving dyn]
   type t1


### PR DESCRIPTION
This adds support for recursive types. Previously all types were assumed to be non recursive by the deriver. Using it on recursive types would trigger a compiler error because of the missing `rec` flag in the converter definition.

It also adds support for multi type defintions (`type t = ... and u = ...`), mutually recursive or otherwise.